### PR TITLE
Embeddings via the LLM gateway (ADR-0029)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ tools/
 /builder-runner
 /bespoke
 /platform
+# /platform is for a stray binary; re-include the source directory so new
+# files under platform/ aren't silently ignored.
+!/platform/
 /platformd
 /testapp
 deploy/deploy.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,12 +74,18 @@ them rather than improvising, whichever agent you are:
   by default. The 16px-input rule in `design/input.css` is load-bearing —
   never remove or override it. A view that needs a mouse is a failed build.
 - LLM inference only via `llm.New(slug)` → `Complete`/`CompleteJSON`/
-  `Classify` ([design](docs/design/llm-gateway.md)); never call a model
-  provider or the Copilot SDK from an app. Expect ~1.5s per call — design
-  features accordingly. Local dev needs platformd running (`just dev`) and
-  the `copilot` CLI authenticated. Tag user-facing completions with
-  `llm.WithUser(user.Login)` so the gateway injects the user's brief
-  (ADR-0019) — chat does this automatically; omit it for mechanical calls.
+  `Classify`/`Embed` ([design](docs/design/llm-gateway.md)); never call a
+  model provider or the Copilot SDK from an app. Expect ~1.5s per
+  completion — design features accordingly. Local dev needs platformd
+  running (`just dev`) and the `copilot` CLI authenticated. Tag user-facing
+  completions with `llm.WithUser(user.Login)` so the gateway injects the
+  user's brief (ADR-0019) — chat does this automatically; omit it for
+  mechanical calls. Embeddings (ADR-0029) are Lemonade-backed with NO
+  stub: handle `llm.ErrEmbedUnavailable` by degrading (lexical search
+  keeps working), store vectors in the app's own SQLite as BLOBs with
+  brute-force `llm.Cosine`, embed on write (best-effort — a failed embed
+  never fails the write), and in a search provider embed only the query,
+  never the corpus.
   Runtime builtins (web fetch/search, read-only GitHub) are a
   gateway-curated allowlist reserved for the dashboard chat via
   `llm.WithBuiltins` (ADR-0024) — apps don't opt in without a new ADR.

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ Docs are split by the question they answer:
 - [0026 — App-bundled chat skills via a loader tool](adr/0026-app-bundled-chat-skills.md)
 - [0027 — Version the platform and keep owner instances private](adr/0027-versioned-platform-private-instances.md)
 - [0028 — Dashboard global search via app fan-out](adr/0028-dashboard-global-search-fan-out.md)
+- [0029 — Embeddings via the LLM gateway](adr/0029-embeddings-via-llm-gateway.md)
 
 ### Design
 

--- a/docs/adr/0029-embeddings-via-llm-gateway.md
+++ b/docs/adr/0029-embeddings-via-llm-gateway.md
@@ -27,9 +27,12 @@ The LLM gateway grows an embeddings endpoint, and apps consume it only
 through `pkg/llm`:
 
 - platformd serves **`POST /llm/embed`** on the internal 4001 plane
-  (ADR-0012): request `{app, texts[]}`, response `{model, embeddings[][]}`,
-  one vector per input text, order preserved. Bounded: at most 64 texts per
-  call, 8KB per text.
+  (ADR-0012): request `{app, kind?, texts[]}`, response `{model,
+  embeddings[][]}`, one vector per input text, order preserved. Bounded: at
+  most 64 texts per call, 8KB per text. `kind` is `"document"` (default) or
+  `"query"` — retrieval models treat the two asymmetrically, and the
+  gateway applies model-specific task prefixes (nomic's `search_document: `
+  / `search_query: `) so apps stay model-blind.
 - The backend is **Lemonade's OpenAI-compatible `/embeddings`** endpoint
   (`BESPOKE_LEMONADE_URL`, the same env the audio gateway uses), model from
   `BESPOKE_EMBED_MODEL` (default `nomic-embed-text-v2-moe`). Apps never see
@@ -38,10 +41,11 @@ through `pkg/llm`:
   `pkg/llm` surfaces `llm.ErrEmbedUnavailable`; fake vectors would silently
   poison stored indexes. Callers MUST degrade — semantic features switch
   off, lexical paths keep working.
-- **`pkg/llm` interface:** `Embed(ctx, texts) ([][]float32, error)` on the
-  existing client, plus the pure helper `llm.Cosine(a, b)` so every app
-  ranks the same way. No options: embeddings are mechanical, never
-  user-brief-tagged.
+- **`pkg/llm` interface:** `Embed(ctx, texts)` for documents and
+  `EmbedQuery(ctx, q)` for queries, both returning `*llm.Embedded{Model,
+  Vectors}` — apps store `Model` beside vectors and re-embed on mismatch —
+  plus the pure helper `llm.Cosine(a, b)` so every app ranks the same way.
+  No options: embeddings are mechanical, never user-brief-tagged.
 - **Vectors live in each app's own SQLite** as BLOB columns, embedded at
   write time (and backfilled opportunistically), compared brute-force with
   cosine in Go. No central vector store, no shared index — the same
@@ -69,8 +73,8 @@ through `pkg/llm`:
   they are sub-second and interruption-safe, so deploys need not wait on
   them.
 - A future model change (`BESPOKE_EMBED_MODEL`) silently invalidates stored
-  vectors — apps SHOULD store the model name alongside vectors and re-embed
-  on mismatch.
+  vectors — apps MUST store `Embedded.Model` alongside vectors, filter
+  ranking to matching-model rows, and let their re-embed sweep converge.
 
 ## Alternatives considered
 

--- a/docs/adr/0029-embeddings-via-llm-gateway.md
+++ b/docs/adr/0029-embeddings-via-llm-gateway.md
@@ -1,0 +1,100 @@
+# 0029 — Embeddings via the LLM gateway
+
+- **Status:** Accepted
+- **Date:** 2026-08-03
+
+## Context
+
+Global search (ADR-0028) is live as lexical per-app search behind `GET
+/_search` — substring or FTS5, the app's choice. Semantic matching ("coffee
+maker" finding the espresso page) needs text embeddings, and the pieces
+already exist: a Lemonade server runs on the app host serving the audio
+gateway (ADR-0014), with `nomic-embed-text-v2-moe` downloaded — the
+internal-services catalog lists Embeddings as a Tier-2 candidate via a
+future `llm.Embed`. Two invariants constrain the design: apps never call a
+model provider directly (ADR-0009 — all inference rides platformd's
+gateway), and the app-search spec forbids search providers from calling the
+LLM gateway so a fan-out with a 900ms timeout is never blocked behind
+completions. Embedding a short query is a different cost class from a
+completion (~tens of milliseconds on-host, no model reasoning), so the
+blanket prohibition overshoots for this one case. Vector *storage* has its
+own constraint: deploys cross-compile with `CGO_ENABLED=0`, so C extensions
+like sqlite-vec are unavailable.
+
+## Decision
+
+The LLM gateway grows an embeddings endpoint, and apps consume it only
+through `pkg/llm`:
+
+- platformd serves **`POST /llm/embed`** on the internal 4001 plane
+  (ADR-0012): request `{app, texts[]}`, response `{model, embeddings[][]}`,
+  one vector per input text, order preserved. Bounded: at most 64 texts per
+  call, 8KB per text.
+- The backend is **Lemonade's OpenAI-compatible `/embeddings`** endpoint
+  (`BESPOKE_LEMONADE_URL`, the same env the audio gateway uses), model from
+  `BESPOKE_EMBED_MODEL` (default `nomic-embed-text-v2-moe`). Apps never see
+  the backend.
+- **No stub mode.** Without a backend the endpoint returns 503 and
+  `pkg/llm` surfaces `llm.ErrEmbedUnavailable`; fake vectors would silently
+  poison stored indexes. Callers MUST degrade — semantic features switch
+  off, lexical paths keep working.
+- **`pkg/llm` interface:** `Embed(ctx, texts) ([][]float32, error)` on the
+  existing client, plus the pure helper `llm.Cosine(a, b)` so every app
+  ranks the same way. No options: embeddings are mechanical, never
+  user-brief-tagged.
+- **Vectors live in each app's own SQLite** as BLOB columns, embedded at
+  write time (and backfilled opportunistically), compared brute-force with
+  cosine in Go. No central vector store, no shared index — the same
+  sovereignty rule as ADR-0028 — and no sqlite-vec (C extension, breaks the
+  CGO-free build). At personal scale (thousands of rows) brute force is
+  sub-millisecond.
+- **App-search carve-out:** the app-search spec's "no LLM gateway calls"
+  rule gains one exception — a search provider MAY make a single
+  `llm.Embed` call to embed **the query text only** (the corpus is embedded
+  at write time, never during a search request). The provider must still
+  answer within platformd's fan-out timeout and fall back to lexical
+  results when embeddings are unavailable or slow.
+
+## Consequences
+
+- Semantic and hybrid search become per-app upgrades behind the unchanged
+  `/_search` contract, exactly as FTS5 was — no platform change per app.
+- One more soft dependency on Lemonade: instances without it lose semantic
+  features but nothing else, matching the audio gateway's degradation
+  story.
+- Write paths that embed acquire a network dependency; apps must treat
+  embedding as best-effort (a failed embed never fails the write) and
+  tolerate rows with missing vectors.
+- Embedding calls are not counted in `/llm/activity` quiesce (ADR-0023):
+  they are sub-second and interruption-safe, so deploys need not wait on
+  them.
+- A future model change (`BESPOKE_EMBED_MODEL`) silently invalidates stored
+  vectors — apps SHOULD store the model name alongside vectors and re-embed
+  on mismatch.
+
+## Alternatives considered
+
+- **Apps call Lemonade directly:** breaks the ADR-0009 invariant that all
+  inference flows through the gateway; loses the single point of
+  observability, bounding, and config. Rejected.
+- **Central platform vector index:** same indexing/invalidation/delete
+  protocol problem that killed the central search index in ADR-0028, plus a
+  shared store eroding per-app isolation (ADR-0007). Rejected.
+- **sqlite-vec (or another vector extension):** C extension; the platform
+  cross-compiles with `CGO_ENABLED=0` and the driver stays modernc.
+  Rejected on build constraints alone; brute-force cosine suffices at this
+  scale.
+- **Stub embeddings in dev (like transcription's stub):** a stub transcript
+  is visibly fake to a human; a stub vector is invisibly wrong and would be
+  persisted. Rejected — absence must be explicit (`ErrEmbedUnavailable`).
+
+## References
+
+- Shapes: [design/llm-gateway.md](../design/llm-gateway.md),
+  [design/internal-services.md](../design/internal-services.md),
+  [specs/app-search.md](../specs/app-search.md)
+- Builds on: [ADR-0007](0007-sqlite-per-app-litestream.md),
+  [ADR-0009](0009-copilot-sdk-llm-gateway.md),
+  [ADR-0012](0012-internal-services-two-tier.md),
+  [ADR-0014](0014-audio-service-transcription.md),
+  [ADR-0028](0028-dashboard-global-search-fan-out.md)

--- a/docs/design/internal-services.md
+++ b/docs/design/internal-services.md
@@ -28,7 +28,7 @@ app ──pkg/* helper────────► (no network at all — compose
 | Files/blobs | 2 | candidate | future `pkg/files` | When two apps first share uploads (ADR-0006) |
 | Notifications | 1 or 2 | candidate | future `pkg/notify` | Tier depends on delivery mechanism |
 | Scheduled jobs | — | candidate | systemd timers per app first | Escalate only if cross-app coordination appears |
-| Embeddings | 2 | candidate | future `llm.Embed` | Backend ready: nomic-embed-text-v2-moe downloaded on Lemonade |
+| Embeddings | 2 | **live** | `llm.Embed(ctx, texts)` + `llm.Cosine` → gateway `/llm/embed` | ADR-0029; Lemonade-backed (nomic-embed-text-v2-moe), no stub — `llm.ErrEmbedUnavailable` without a backend; vectors stored per-app as SQLite BLOBs |
 | Global search | — | **live** | `web.Search(mux, provider)` → `GET /_search?q=`; dashboard box + `search` MCP/chat tool | ADR-0028; HTTP fan-out (like cards), grouped by app, never their databases; no central index |
 | Image generation | 2 | candidate | future `llm.Image` | Backend: Lemonade on selfie |
 | Private/local completion | 2 | candidate | future `llm` option (e.g. `WithLocal()`) | Route privacy-sensitive prompts to Lemonade instead of Copilot |
@@ -91,7 +91,9 @@ The gateway pattern (ADR-0009/0012) means backends are invisible to apps —
   **transcription works** (Whisper-Large-v3-Turbo; the first call after
   idle loads the model and is slow — budget for it), **TTS works**
   (kokoro-v1 generated real audio), and `nomic-embed-text-v2-moe-GGUF` is
-  downloaded for future `llm.Embed`. Transcription accepts **WAV only** —
+  downloaded and serving `llm.Embed`
+  ([ADR-0029](../adr/0029-embeddings-via-llm-gateway.md)). Transcription
+  accepts **WAV only** —
   the pkg/ui recorder encodes WAV client-side for exactly this reason.
 
 ## Adding a capability (decision tree)

--- a/docs/design/internal-services.md
+++ b/docs/design/internal-services.md
@@ -28,7 +28,7 @@ app ──pkg/* helper────────► (no network at all — compose
 | Files/blobs | 2 | candidate | future `pkg/files` | When two apps first share uploads (ADR-0006) |
 | Notifications | 1 or 2 | candidate | future `pkg/notify` | Tier depends on delivery mechanism |
 | Scheduled jobs | — | candidate | systemd timers per app first | Escalate only if cross-app coordination appears |
-| Embeddings | 2 | **live** | `llm.Embed(ctx, texts)` + `llm.Cosine` → gateway `/llm/embed` | ADR-0029; Lemonade-backed (nomic-embed-text-v2-moe), no stub — `llm.ErrEmbedUnavailable` without a backend; vectors stored per-app as SQLite BLOBs |
+| Embeddings | 2 | **live** | `llm.Embed(ctx, texts)` / `llm.EmbedQuery(ctx, q)` + `llm.Cosine` → gateway `/llm/embed` | ADR-0029; Lemonade-backed (nomic-embed-text-v2-moe, task prefixes applied by the gateway), no stub — `llm.ErrEmbedUnavailable` without a backend; vectors + model stored per-app as SQLite BLOBs |
 | Global search | — | **live** | `web.Search(mux, provider)` → `GET /_search?q=`; dashboard box + `search` MCP/chat tool | ADR-0028; HTTP fan-out (like cards), grouped by app, never their databases; no central index |
 | Image generation | 2 | candidate | future `llm.Image` | Backend: Lemonade on selfie |
 | Private/local completion | 2 | candidate | future `llm` option (e.g. `WithLocal()`) | Route privacy-sensitive prompts to Lemonade instead of Copilot |

--- a/docs/design/llm-gateway.md
+++ b/docs/design/llm-gateway.md
@@ -63,6 +63,17 @@ app ──pkg/llm──► platformd :4001 /llm/* ──Copilot SDK──► cop
   [internal-services.md](internal-services.md).
   Streaming is deferred until the first app needs it (the SDK supports
   message deltas; add a `/llm/stream` SSE endpoint then).
+- **Embeddings ([ADR-0029](../adr/0029-embeddings-via-llm-gateway.md)):**
+  `POST /llm/embed` on the same plane — `{app, texts[]}` in, `{model,
+  embeddings[][]}` out (≤64 texts of ≤8KB per call), backed by Lemonade's
+  OpenAI-compatible `/embeddings` (`BESPOKE_LEMONADE_URL`, model from
+  `BESPOKE_EMBED_MODEL`, default `nomic-embed-text-v2-moe`). Client side:
+  `Embed(ctx, texts)` plus the pure ranking helper `llm.Cosine(a, b)`.
+  **No stub mode** — without a backend the endpoint 503s and `pkg/llm`
+  returns `llm.ErrEmbedUnavailable`; apps degrade to lexical paths. Vectors
+  are stored per-app (SQLite BLOBs, brute-force cosine — no C extensions),
+  embedded at write time. Embed calls are not counted in `/llm/activity`
+  quiesce: sub-second and interruption-safe.
 - **Model selection** is gateway config: `BESPOKE_LLM_MODEL` env on platformd
   (empty = CLI default). Apps never specify a model.
 - **User brief injection ([ADR-0019](../adr/0019-user-brief.md)):** requests
@@ -73,7 +84,9 @@ app ──pkg/llm──► platformd :4001 /llm/* ──Copilot SDK──► cop
   [Lemonade](https://lemonade-server.ai/) server runs locally on selfie
   (OpenAI-compatible). The audio gateway uses it in production — Whisper
   transcription in, kokoro TTS out — behind the same plane
-  ([ADR-0014](../adr/0014-audio-service-transcription.md)). Text completion
+  ([ADR-0014](../adr/0014-audio-service-transcription.md)), and text
+  embeddings via `/llm/embed`
+  ([ADR-0029](../adr/0029-embeddings-via-llm-gateway.md)). Text completion
   on Lemonade remains a candidate: when adopted it slots in behind the same
   `pkg/llm` seam, with a future explicit privacy option (e.g. `WithLocal()`,
   not yet implemented) for prompts that must not leave the house. See the
@@ -105,6 +118,9 @@ app ──pkg/llm──► platformd :4001 /llm/* ──Copilot SDK──► cop
   search (ADR-0025); missing key degrades `web_search` to fetch-based
   search. Add both to `~/bespoke/env` on the app host and restart
   platformd.
+- Soft dependency: `BESPOKE_LEMONADE_URL` for embeddings (ADR-0029, same
+  env the audio gateway uses); missing it makes `/llm/embed` return 503
+  and apps fall back to lexical search.
 - platformd checks `GetAuthStatus` at startup and every 5 minutes; failures
   surface as a dashboard warning banner, and `/llm/healthz` returns 503.
   The gateway starting/down never blocks the dashboard.

--- a/docs/design/llm-gateway.md
+++ b/docs/design/llm-gateway.md
@@ -64,11 +64,14 @@ app ──pkg/llm──► platformd :4001 /llm/* ──Copilot SDK──► cop
   Streaming is deferred until the first app needs it (the SDK supports
   message deltas; add a `/llm/stream` SSE endpoint then).
 - **Embeddings ([ADR-0029](../adr/0029-embeddings-via-llm-gateway.md)):**
-  `POST /llm/embed` on the same plane — `{app, texts[]}` in, `{model,
-  embeddings[][]}` out (≤64 texts of ≤8KB per call), backed by Lemonade's
-  OpenAI-compatible `/embeddings` (`BESPOKE_LEMONADE_URL`, model from
-  `BESPOKE_EMBED_MODEL`, default `nomic-embed-text-v2-moe`). Client side:
-  `Embed(ctx, texts)` plus the pure ranking helper `llm.Cosine(a, b)`.
+  `POST /llm/embed` on the same plane — `{app, kind?, texts[]}` in,
+  `{model, embeddings[][]}` out (≤64 texts of ≤8KB per call), backed by
+  Lemonade's OpenAI-compatible `/embeddings` (`BESPOKE_LEMONADE_URL`, model
+  from `BESPOKE_EMBED_MODEL`, default `nomic-embed-text-v2-moe`). The
+  gateway applies model-specific retrieval prefixes per `kind` (documents
+  vs queries), keeping apps model-blind. Client side: `Embed(ctx, texts)` /
+  `EmbedQuery(ctx, q)` → `*llm.Embedded{Model, Vectors}` plus the pure
+  ranking helper `llm.Cosine(a, b)`.
   **No stub mode** — without a backend the endpoint 503s and `pkg/llm`
   returns `llm.ErrEmbedUnavailable`; apps degrade to lexical paths. Vectors
   are stored per-app (SQLite BLOBs, brute-force cosine — no C extensions),

--- a/docs/specs/app-search.md
+++ b/docs/specs/app-search.md
@@ -47,8 +47,13 @@ Each result:
   empty). Malformed, slow (beyond platformd's timeout), oversized (beyond
   platformd's cap), or absent responses cause the app to be dropped from
   results — never an error surfaced to the user.
-- Providers MUST be cheap database queries; they MUST NOT call the LLM gateway
-  or other network services.
+- Providers MUST be cheap database queries; they MUST NOT run LLM
+  completions or call other network services. Sole carve-out
+  ([ADR-0029](../adr/0029-embeddings-via-llm-gateway.md)): one `llm.Embed`
+  call to embed **the query text only** — corpus embedding happens at write
+  time, never during a search request — and the provider MUST still answer
+  within platformd's timeout, falling back to lexical results when
+  embeddings are unavailable (`llm.ErrEmbedUnavailable`) or slow.
 - An app that does not register `/_search` is silently absent from search.
 
 ## Derived artifacts
@@ -60,6 +65,8 @@ Each result:
 
 ## References
 
-- Rationale: [ADR-0028](../adr/0028-dashboard-global-search-fan-out.md)
+- Rationale: [ADR-0028](../adr/0028-dashboard-global-search-fan-out.md);
+  query-embedding carve-out:
+  [ADR-0029](../adr/0029-embeddings-via-llm-gateway.md)
 - Context: [design/internal-services.md](../design/internal-services.md),
   [specs/app-manifest.md](app-manifest.md)

--- a/pkg/llm/embed.go
+++ b/pkg/llm/embed.go
@@ -1,0 +1,78 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"strings"
+)
+
+// ErrEmbedUnavailable reports that the gateway has no embeddings backend
+// (BESPOKE_LEMONADE_URL unset on platformd). Callers MUST degrade — switch
+// semantic features off and keep lexical paths working — rather than fail
+// the surrounding feature (ADR-0029).
+var ErrEmbedUnavailable = errors.New("embeddings unavailable")
+
+// Embed returns one vector per text, in input order, via the gateway's
+// Lemonade-backed embeddings endpoint (ADR-0029). Rank with llm.Cosine.
+// Mechanical like Classify — no options, never user-brief-tagged. At most
+// 64 texts of 8KB each per call; embedding is best-effort by design, so a
+// failed Embed should never fail the write that triggered it.
+func (c *Client) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	body, _ := json.Marshal(map[string]any{"app": c.app, "texts": texts})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.base+"/llm/embed", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("llm gateway: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusServiceUnavailable {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("%w: %s", ErrEmbedUnavailable, strings.TrimSpace(string(msg)))
+	}
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("llm gateway: %s: %s", resp.Status, strings.TrimSpace(string(msg)))
+	}
+	var out struct {
+		Embeddings [][]float32 `json:"embeddings"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	if len(out.Embeddings) != len(texts) {
+		return nil, fmt.Errorf("llm gateway: got %d embeddings for %d texts", len(out.Embeddings), len(texts))
+	}
+	return out.Embeddings, nil
+}
+
+// Cosine returns the cosine similarity of two vectors in [-1, 1], or 0 for
+// mismatched or zero-magnitude inputs. The one ranking function every app
+// uses, so scores stay comparable across the platform (ADR-0029).
+func Cosine(a, b []float32) float64 {
+	if len(a) == 0 || len(a) != len(b) {
+		return 0
+	}
+	var dot, na, nb float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+		na += float64(a[i]) * float64(a[i])
+		nb += float64(b[i]) * float64(b[i])
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return dot / (math.Sqrt(na) * math.Sqrt(nb))
+}

--- a/pkg/llm/embed.go
+++ b/pkg/llm/embed.go
@@ -18,16 +18,37 @@ import (
 // the surrounding feature (ADR-0029).
 var ErrEmbedUnavailable = errors.New("embeddings unavailable")
 
-// Embed returns one vector per text, in input order, via the gateway's
-// Lemonade-backed embeddings endpoint (ADR-0029). Rank with llm.Cosine.
-// Mechanical like Classify — no options, never user-brief-tagged. At most
-// 64 texts of 8KB each per call; embedding is best-effort by design, so a
-// failed Embed should never fail the write that triggered it.
-func (c *Client) Embed(ctx context.Context, texts []string) ([][]float32, error) {
+// Embedded is the result of an embedding call: one vector per input text,
+// in input order, plus the backend model that produced them. Store Model
+// alongside vectors — a model change invalidates them (ADR-0029).
+type Embedded struct {
+	Model   string
+	Vectors [][]float32
+}
+
+// Embed embeds documents for storage and later ranking with llm.Cosine
+// (ADR-0029). Mechanical like Classify — no options, never
+// user-brief-tagged. At most 64 texts of 8KB each per call; embedding is
+// best-effort by design, so a failed Embed should never fail the write
+// that triggered it. Returns ErrEmbedUnavailable (wrapped) when the
+// gateway has no backend.
+func (c *Client) Embed(ctx context.Context, texts []string) (*Embedded, error) {
+	return c.embed(ctx, "document", texts)
+}
+
+// EmbedQuery embeds a search query for ranking against stored document
+// vectors (retrieval models treat queries and documents asymmetrically;
+// the gateway applies the model's task prefixes). One text in, one vector
+// out at Vectors[0].
+func (c *Client) EmbedQuery(ctx context.Context, q string) (*Embedded, error) {
+	return c.embed(ctx, "query", []string{q})
+}
+
+func (c *Client) embed(ctx context.Context, kind string, texts []string) (*Embedded, error) {
 	if len(texts) == 0 {
-		return nil, nil
+		return &Embedded{}, nil
 	}
-	body, _ := json.Marshal(map[string]any{"app": c.app, "texts": texts})
+	body, _ := json.Marshal(map[string]any{"app": c.app, "kind": kind, "texts": texts})
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.base+"/llm/embed", bytes.NewReader(body))
 	if err != nil {
 		return nil, err
@@ -47,6 +68,7 @@ func (c *Client) Embed(ctx context.Context, texts []string) ([][]float32, error)
 		return nil, fmt.Errorf("llm gateway: %s: %s", resp.Status, strings.TrimSpace(string(msg)))
 	}
 	var out struct {
+		Model      string      `json:"model"`
 		Embeddings [][]float32 `json:"embeddings"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
@@ -55,7 +77,7 @@ func (c *Client) Embed(ctx context.Context, texts []string) ([][]float32, error)
 	if len(out.Embeddings) != len(texts) {
 		return nil, fmt.Errorf("llm gateway: got %d embeddings for %d texts", len(out.Embeddings), len(texts))
 	}
-	return out.Embeddings, nil
+	return &Embedded{Model: out.Model, Vectors: out.Embeddings}, nil
 }
 
 // Cosine returns the cosine similarity of two vectors in [-1, 1], or 0 for

--- a/pkg/llm/embed_test.go
+++ b/pkg/llm/embed_test.go
@@ -23,10 +23,15 @@ func TestEmbed(t *testing.T) {
 		}
 		var req struct {
 			App   string   `json:"app"`
+			Kind  string   `json:"kind"`
 			Texts []string `json:"texts"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.App != "test" {
 			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		if req.Kind != "document" && req.Kind != "query" {
+			http.Error(w, "bad kind "+req.Kind, http.StatusBadRequest)
 			return
 		}
 		vecs := make([][]float32, len(req.Texts))
@@ -41,12 +46,20 @@ func TestEmbed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(got) != 2 || got[1][0] != 1 {
-		t.Fatalf("unexpected embeddings: %v", got)
+	if got.Model != "m" || len(got.Vectors) != 2 || got.Vectors[1][0] != 1 {
+		t.Fatalf("unexpected embeddings: %+v", got)
 	}
 
-	if got, err := embedClient(srv.URL).Embed(context.Background(), nil); got != nil || err != nil {
-		t.Errorf("empty input: want nil, nil; got %v, %v", got, err)
+	qv, err := embedClient(srv.URL).EmbedQuery(context.Background(), "find me")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(qv.Vectors) != 1 {
+		t.Fatalf("query: want 1 vector, got %+v", qv)
+	}
+
+	if got, err := embedClient(srv.URL).Embed(context.Background(), nil); err != nil || len(got.Vectors) != 0 {
+		t.Errorf("empty input: want empty result, got %+v, %v", got, err)
 	}
 }
 

--- a/pkg/llm/embed_test.go
+++ b/pkg/llm/embed_test.go
@@ -1,0 +1,81 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func embedClient(base string) *Client {
+	return &Client{app: "test", base: base, hc: &http.Client{Timeout: 5 * time.Second}}
+}
+
+func TestEmbed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/llm/embed" {
+			http.NotFound(w, r)
+			return
+		}
+		var req struct {
+			App   string   `json:"app"`
+			Texts []string `json:"texts"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.App != "test" {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		vecs := make([][]float32, len(req.Texts))
+		for i := range vecs {
+			vecs[i] = []float32{float32(i), 1}
+		}
+		json.NewEncoder(w).Encode(map[string]any{"model": "m", "embeddings": vecs})
+	}))
+	defer srv.Close()
+
+	got, err := embedClient(srv.URL).Embed(context.Background(), []string{"a", "b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[1][0] != 1 {
+		t.Fatalf("unexpected embeddings: %v", got)
+	}
+
+	if got, err := embedClient(srv.URL).Embed(context.Background(), nil); got != nil || err != nil {
+		t.Errorf("empty input: want nil, nil; got %v, %v", got, err)
+	}
+}
+
+func TestEmbedUnavailable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "embeddings unavailable: BESPOKE_LEMONADE_URL unset", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	_, err := embedClient(srv.URL).Embed(context.Background(), []string{"a"})
+	if !errors.Is(err, ErrEmbedUnavailable) {
+		t.Fatalf("want ErrEmbedUnavailable, got %v", err)
+	}
+}
+
+func TestCosine(t *testing.T) {
+	if got := Cosine([]float32{1, 0}, []float32{1, 0}); math.Abs(got-1) > 1e-9 {
+		t.Errorf("identical vectors: want 1, got %v", got)
+	}
+	if got := Cosine([]float32{1, 0}, []float32{0, 1}); math.Abs(got) > 1e-9 {
+		t.Errorf("orthogonal vectors: want 0, got %v", got)
+	}
+	if got := Cosine([]float32{1, 0}, []float32{-1, 0}); math.Abs(got+1) > 1e-9 {
+		t.Errorf("opposite vectors: want -1, got %v", got)
+	}
+	if got := Cosine([]float32{1}, []float32{1, 2}); got != 0 {
+		t.Errorf("mismatched lengths: want 0, got %v", got)
+	}
+	if got := Cosine([]float32{0, 0}, []float32{1, 0}); got != 0 {
+		t.Errorf("zero vector: want 0, got %v", got)
+	}
+}

--- a/platform/embed.go
+++ b/platform/embed.go
@@ -1,0 +1,119 @@
+// The embeddings gateway (ADR-0029): POST /llm/embed on the internal 4001
+// plane, backed by Lemonade's OpenAI-compatible /embeddings endpoint when
+// BESPOKE_LEMONADE_URL is set. No stub mode — fake vectors would silently
+// poison stored indexes, so without a backend the endpoint returns 503 and
+// pkg/llm surfaces ErrEmbedUnavailable for callers to degrade on.
+package main
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	embedMaxTexts    = 64
+	embedMaxTextSize = 8 << 10
+)
+
+type embedGateway struct {
+	base  string // Lemonade OpenAI-compatible base URL; empty = unavailable
+	model string
+	hc    *http.Client
+}
+
+func newEmbedGateway() *embedGateway {
+	return &embedGateway{
+		base:  strings.TrimSuffix(os.Getenv("BESPOKE_LEMONADE_URL"), "/"),
+		model: cmp.Or(os.Getenv("BESPOKE_EMBED_MODEL"), "nomic-embed-text-v2-moe"),
+		hc:    &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+func (g *embedGateway) register(mux *http.ServeMux) {
+	mux.HandleFunc("POST /llm/embed", func(w http.ResponseWriter, r *http.Request) {
+		if g.base == "" {
+			http.Error(w, "embeddings unavailable: BESPOKE_LEMONADE_URL unset", http.StatusServiceUnavailable)
+			return
+		}
+		var req struct {
+			App   string   `json:"app"`
+			Texts []string `json:"texts"`
+		}
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil || len(req.Texts) == 0 {
+			http.Error(w, "bad request: need {app, texts}", http.StatusBadRequest)
+			return
+		}
+		if len(req.Texts) > embedMaxTexts {
+			http.Error(w, fmt.Sprintf("too many texts (max %d per call)", embedMaxTexts), http.StatusBadRequest)
+			return
+		}
+		for i, t := range req.Texts {
+			if len(t) > embedMaxTextSize {
+				http.Error(w, fmt.Sprintf("text %d too large (max %dB)", i, embedMaxTextSize), http.StatusBadRequest)
+				return
+			}
+		}
+		start := time.Now()
+		vecs, err := g.embed(r.Context(), req.Texts)
+		log.Printf("embed app=%s texts=%d dur=%s err=%v",
+			req.App, len(req.Texts), time.Since(start).Round(time.Millisecond), err)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{"model": g.model, "embeddings": vecs})
+	})
+}
+
+// embed calls Lemonade's OpenAI-compatible embeddings endpoint and returns
+// one vector per input, in input order (the response's index field is
+// authoritative, not its array position).
+func (g *embedGateway) embed(ctx context.Context, texts []string) ([][]float32, error) {
+	body, _ := json.Marshal(map[string]any{"model": g.model, "input": texts})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, g.base+"/embeddings", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := g.hc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("lemonade: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("lemonade: %s: %s", resp.Status, strings.TrimSpace(string(msg)))
+	}
+	var out struct {
+		Data []struct {
+			Index     int       `json:"index"`
+			Embedding []float32 `json:"embedding"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("lemonade: %w", err)
+	}
+	if len(out.Data) != len(texts) {
+		return nil, fmt.Errorf("lemonade: got %d embeddings for %d texts", len(out.Data), len(texts))
+	}
+	vecs := make([][]float32, len(texts))
+	for _, d := range out.Data {
+		if d.Index < 0 || d.Index >= len(vecs) || vecs[d.Index] != nil {
+			return nil, fmt.Errorf("lemonade: bad embedding index %d", d.Index)
+		}
+		if len(d.Embedding) == 0 {
+			return nil, fmt.Errorf("lemonade: empty embedding at index %d", d.Index)
+		}
+		vecs[d.Index] = d.Embedding
+	}
+	return vecs, nil
+}

--- a/platform/embed.go
+++ b/platform/embed.go
@@ -46,10 +46,18 @@ func (g *embedGateway) register(mux *http.ServeMux) {
 		}
 		var req struct {
 			App   string   `json:"app"`
+			Kind  string   `json:"kind"` // "document" (default) or "query"
 			Texts []string `json:"texts"`
 		}
 		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil || len(req.Texts) == 0 {
 			http.Error(w, "bad request: need {app, texts}", http.StatusBadRequest)
+			return
+		}
+		if req.Kind == "" {
+			req.Kind = "document"
+		}
+		if req.Kind != "document" && req.Kind != "query" {
+			http.Error(w, `kind must be "document" or "query"`, http.StatusBadRequest)
 			return
 		}
 		if len(req.Texts) > embedMaxTexts {
@@ -63,9 +71,9 @@ func (g *embedGateway) register(mux *http.ServeMux) {
 			}
 		}
 		start := time.Now()
-		vecs, err := g.embed(r.Context(), req.Texts)
-		log.Printf("embed app=%s texts=%d dur=%s err=%v",
-			req.App, len(req.Texts), time.Since(start).Round(time.Millisecond), err)
+		vecs, err := g.embed(r.Context(), req.Kind, req.Texts)
+		log.Printf("embed app=%s kind=%s texts=%d dur=%s err=%v",
+			req.App, req.Kind, len(req.Texts), time.Since(start).Round(time.Millisecond), err)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadGateway)
 			return
@@ -76,8 +84,20 @@ func (g *embedGateway) register(mux *http.ServeMux) {
 
 // embed calls Lemonade's OpenAI-compatible embeddings endpoint and returns
 // one vector per input, in input order (the response's index field is
-// authoritative, not its array position).
-func (g *embedGateway) embed(ctx context.Context, texts []string) ([][]float32, error) {
+// authoritative, not its array position). Nomic models want retrieval task
+// prefixes — the gateway adds them so apps stay model-blind.
+func (g *embedGateway) embed(ctx context.Context, kind string, texts []string) ([][]float32, error) {
+	if strings.HasPrefix(g.model, "nomic-embed") {
+		prefix := "search_document: "
+		if kind == "query" {
+			prefix = "search_query: "
+		}
+		prefixed := make([]string, len(texts))
+		for i, t := range texts {
+			prefixed[i] = prefix + t
+		}
+		texts = prefixed
+	}
 	body, _ := json.Marshal(map[string]any{"model": g.model, "input": texts})
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, g.base+"/embeddings", bytes.NewReader(body))
 	if err != nil {

--- a/platform/embed_test.go
+++ b/platform/embed_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeLemonade serves an OpenAI-compatible /embeddings endpoint returning a
+// distinct vector per input, deliberately in reverse index order to prove
+// the gateway reorders by the index field.
+func fakeLemonade(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/embeddings" {
+			http.NotFound(w, r)
+			return
+		}
+		var req struct {
+			Input []string `json:"input"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		type datum struct {
+			Index     int       `json:"index"`
+			Embedding []float32 `json:"embedding"`
+		}
+		var data []datum
+		for i := len(req.Input) - 1; i >= 0; i-- {
+			data = append(data, datum{Index: i, Embedding: []float32{float32(i), 1}})
+		}
+		json.NewEncoder(w).Encode(map[string]any{"data": data})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func embedRequest(t *testing.T, g *embedGateway, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	mux := http.NewServeMux()
+	g.register(mux)
+	req := httptest.NewRequest(http.MethodPost, "/llm/embed", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestEmbedGateway(t *testing.T) {
+	srv := fakeLemonade(t)
+	g := &embedGateway{base: srv.URL, model: "test-model", hc: &http.Client{Timeout: 5 * time.Second}}
+
+	rec := embedRequest(t, g, `{"app":"notes","texts":["alpha","beta","gamma"]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	var out struct {
+		Model      string      `json:"model"`
+		Embeddings [][]float32 `json:"embeddings"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Model != "test-model" || len(out.Embeddings) != 3 {
+		t.Fatalf("bad response: %+v", out)
+	}
+	for i, v := range out.Embeddings {
+		if len(v) != 2 || v[0] != float32(i) {
+			t.Errorf("embedding %d out of order or malformed: %v", i, v)
+		}
+	}
+}
+
+func TestEmbedGatewayUnavailable(t *testing.T) {
+	g := &embedGateway{hc: http.DefaultClient}
+	rec := embedRequest(t, g, `{"app":"notes","texts":["alpha"]}`)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("want 503 without backend, got %d", rec.Code)
+	}
+}
+
+func TestEmbedGatewayBounds(t *testing.T) {
+	srv := fakeLemonade(t)
+	g := &embedGateway{base: srv.URL, model: "m", hc: http.DefaultClient}
+
+	if rec := embedRequest(t, g, `{"app":"notes","texts":[]}`); rec.Code != http.StatusBadRequest {
+		t.Errorf("empty texts: want 400, got %d", rec.Code)
+	}
+	big, _ := json.Marshal(map[string]any{"app": "notes", "texts": []string{strings.Repeat("x", embedMaxTextSize+1)}})
+	if rec := embedRequest(t, g, string(big)); rec.Code != http.StatusBadRequest {
+		t.Errorf("oversized text: want 400, got %d", rec.Code)
+	}
+	many, _ := json.Marshal(map[string]any{"app": "notes", "texts": make([]string, embedMaxTexts+1)})
+	if rec := embedRequest(t, g, string(many)); rec.Code != http.StatusBadRequest {
+		t.Errorf("too many texts: want 400, got %d", rec.Code)
+	}
+}

--- a/platform/embed_test.go
+++ b/platform/embed_test.go
@@ -9,6 +9,10 @@ import (
 	"time"
 )
 
+// lastInputs records the most recent input batch the fake Lemonade saw, so
+// tests can assert on model-specific task prefixes.
+var lastInputs []string
+
 // fakeLemonade serves an OpenAI-compatible /embeddings endpoint returning a
 // distinct vector per input, deliberately in reverse index order to prove
 // the gateway reorders by the index field.
@@ -34,6 +38,7 @@ func fakeLemonade(t *testing.T) *httptest.Server {
 		for i := len(req.Input) - 1; i >= 0; i-- {
 			data = append(data, datum{Index: i, Embedding: []float32{float32(i), 1}})
 		}
+		lastInputs = req.Input
 		json.NewEncoder(w).Encode(map[string]any{"data": data})
 	}))
 	t.Cleanup(srv.Close)
@@ -72,6 +77,36 @@ func TestEmbedGateway(t *testing.T) {
 		if len(v) != 2 || v[0] != float32(i) {
 			t.Errorf("embedding %d out of order or malformed: %v", i, v)
 		}
+	}
+}
+
+func TestEmbedGatewayNomicPrefixes(t *testing.T) {
+	srv := fakeLemonade(t)
+	g := &embedGateway{base: srv.URL, model: "nomic-embed-text-v2-moe", hc: http.DefaultClient}
+
+	if rec := embedRequest(t, g, `{"app":"notes","kind":"query","texts":["milk"]}`); rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	if len(lastInputs) != 1 || lastInputs[0] != "search_query: milk" {
+		t.Errorf("query prefix missing: %q", lastInputs)
+	}
+	if rec := embedRequest(t, g, `{"app":"notes","texts":["milk"]}`); rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	if len(lastInputs) != 1 || lastInputs[0] != "search_document: milk" {
+		t.Errorf("document prefix missing: %q", lastInputs)
+	}
+
+	g.model = "some-other-model"
+	if rec := embedRequest(t, g, `{"app":"notes","kind":"query","texts":["milk"]}`); rec.Code != http.StatusOK {
+		t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+	}
+	if len(lastInputs) != 1 || lastInputs[0] != "milk" {
+		t.Errorf("non-nomic model should get no prefix: %q", lastInputs)
+	}
+
+	if rec := embedRequest(t, g, `{"app":"notes","kind":"nonsense","texts":["milk"]}`); rec.Code != http.StatusBadRequest {
+		t.Errorf("bad kind: want 400, got %d", rec.Code)
 	}
 }
 

--- a/platform/llm.go
+++ b/platform/llm.go
@@ -313,10 +313,11 @@ func copilotTools(tools []wireTool, login string) []copilot.Tool {
 
 // serveInternal runs the internal-services listener (the 4001 plane,
 // ADR-0012) — never routed by Caddy.
-func serveInternal(addr string, llm *llmGateway, audio *audioGateway) {
+func serveInternal(addr string, llm *llmGateway, audio *audioGateway, embed *embedGateway) {
 	mux := http.NewServeMux()
 	llm.register(mux)
 	audio.register(mux)
+	embed.register(mux)
 	// Change notifications from apps (ADR-0022): wake the dashboard's
 	// /_live subscribers so cards refresh on any app's mutation.
 	mux.HandleFunc("POST /notify", func(w http.ResponseWriter, r *http.Request) {

--- a/platform/main.go
+++ b/platform/main.go
@@ -48,9 +48,10 @@ func main() {
 	gw.briefs = sqldb // gateway injects per-user briefs (ADR-0019)
 	go gw.start()
 	agw := newAudioGateway()
+	egw := newEmbedGateway()
 
 	web.Serve("platformd", 4000, func(mux *http.ServeMux) {
-		go serveInternal(*internal, gw, agw) // after flag.Parse (inside Serve)
+		go serveInternal(*internal, gw, agw, egw) // after flag.Parse (inside Serve)
 
 		// The all-apps chat (ADR-0020): context aggregated from every
 		// chat-enabled app over the app contract — never their databases.


### PR DESCRIPTION
## Summary

Adds text embeddings as a platform capability behind the LLM gateway, per [ADR-0029](docs/adr/0029-embeddings-via-llm-gateway.md): `POST /llm/embed` on the internal 4001 plane, backed by Lemonade's OpenAI-compatible `/embeddings` endpoint, consumed by apps only through `pkg/llm`.

## What's included

- **`POST /llm/embed`** (`platform/embed.go`) — `{app, texts[]}` → `{model, embeddings[][]}`, one vector per text in input order (reordered by the response `index` field). Bounded: ≤64 texts, ≤8KB each. Backend from `BESPOKE_LEMONADE_URL` (same env as audio), model from `BESPOKE_EMBED_MODEL` (default `nomic-embed-text-v2-moe`). **No stub mode** — without a backend it returns 503; fake vectors would silently poison stored indexes.
- **`llm.Embed(ctx, texts)` + `llm.Cosine(a, b)`** (`pkg/llm/embed.go`) — client method plus the shared ranking helper; 503 surfaces as `llm.ErrEmbedUnavailable` so apps degrade to lexical search.
- **App-search carve-out** — the spec now allows a search provider exactly one `llm.Embed` call to embed *the query text* (corpus embedding happens at write time), still bounded by platformd's fan-out timeout.
- **Docs** — ADR-0029; gateway design doc; internal-services catalog (Embeddings → live); app-search spec; AGENTS.md guidance (degrade on unavailable, BLOB vectors per app, embed on write best-effort); docs index.
- **Repo fix** — the `/platform` gitignore entry (for a stray binary) also matched the `platform/` source directory, silently making new files there unstageable; a `!/platform/` re-include fixes it.

## Invariants preserved

Apps never talk to a model provider — embeddings ride the same gateway seam as completions (ADR-0009). No central vector store: vectors live in each app's own SQLite as BLOBs with brute-force cosine (ADR-0007 isolation, CGO-free build — no sqlite-vec).

## Verification

`just check` passes (vet, tests, golangci-lint 0 issues, tidy, CGO-free cross-compile). Tests cover: gateway reordering by index, 503 without backend, size/count bounds, client round-trip, `ErrEmbedUnavailable` detection, and `Cosine` properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)